### PR TITLE
Replace channels

### DIFF
--- a/fileUtils.go
+++ b/fileUtils.go
@@ -16,7 +16,7 @@ func getFilesForMonitoring(files []os.DirEntry, maxLength int) []os.DirEntry {
 	return filesSlice
 }
 
-func sortDirEntryByModTime(files []os.DirEntry) []os.DirEntry{
+func sortDirEntryByModTime(files []os.DirEntry) []os.DirEntry {
 	sort.Slice(files, func(i, j int) bool {
 		fileI, err := files[i].Info()
 		if err != nil {
@@ -27,14 +27,14 @@ func sortDirEntryByModTime(files []os.DirEntry) []os.DirEntry{
 		if err != nil {
 			println("Unable to read file %s , while sorting", fileJ.Name())
 			os.Exit(1)
-		}		
+		}
 		return fileI.ModTime().Before(fileJ.ModTime())
 
 	})
 	return files
 }
 
-func sortMonitoredFilesByModTime(files []monitoredFile) []monitoredFile{
+func sortMonitoredFilesByModTime(files []monitoredFile) []monitoredFile {
 	sort.Slice(files, func(i, j int) bool {
 		fileI, err := files[i].file.Info()
 		if err != nil {
@@ -45,7 +45,7 @@ func sortMonitoredFilesByModTime(files []monitoredFile) []monitoredFile{
 		if err != nil {
 			println("Unable to read file %s , while sorting", fileJ.Name())
 			os.Exit(1)
-		}		
+		}
 		return fileI.ModTime().After(fileJ.ModTime())
 
 	})
@@ -74,6 +74,7 @@ func isEligibleFile(fi os.FileInfo) bool {
 	fn := fi.Name()
 	for _, s := range excludedFiles {
 		if strings.Contains(fn, s) {
+			println("Name is in excludes")
 			return false
 		}
 	}

--- a/fileUtils.go
+++ b/fileUtils.go
@@ -36,8 +36,16 @@ func sortDirEntryByModTime(files []os.DirEntry) []os.DirEntry{
 
 func sortMonitoredFilesByModTime(files []monitoredFile) []monitoredFile{
 	sort.Slice(files, func(i, j int) bool {
-		fileI:= files[i].file
-		fileJ:= files[j].file
+		fileI, err := files[i].file.Info()
+		if err != nil {
+			println("Unable to read file %s , while sorting", fileI.Name())
+			os.Exit(1)
+		}
+		fileJ, err := files[j].file.Info()
+		if err != nil {
+			println("Unable to read file %s , while sorting", fileJ.Name())
+			os.Exit(1)
+		}		
 		return fileI.ModTime().After(fileJ.ModTime())
 
 	})

--- a/fileUtils.go
+++ b/fileUtils.go
@@ -8,7 +8,7 @@ import (
 
 func getFilesForMonitoring(files []os.DirEntry, maxLength int) []os.DirEntry {
 	files = removeIneligibleFiles(files)
-	files = sortFilesByModTime(files)
+	files = sortDirEntryByModTime(files)
 
 	sliceSize := getSmallestInt(len(files), maxLength)
 	filesSlice := files[len(files)-sliceSize:]
@@ -16,11 +16,29 @@ func getFilesForMonitoring(files []os.DirEntry, maxLength int) []os.DirEntry {
 	return filesSlice
 }
 
-func sortFilesByModTime(files []monitoredFile) []monitoredFile{
+func sortDirEntryByModTime(files []os.DirEntry) []os.DirEntry{
+	sort.Slice(files, func(i, j int) bool {
+		fileI, err := files[i].Info()
+		if err != nil {
+			println("Unable to read file %s , while sorting", fileI.Name())
+			os.Exit(1)
+		}
+		fileJ, err := files[j].Info()
+		if err != nil {
+			println("Unable to read file %s , while sorting", fileJ.Name())
+			os.Exit(1)
+		}		
+		return fileI.ModTime().Before(fileJ.ModTime())
+
+	})
+	return files
+}
+
+func sortMonitoredFilesByModTime(files []monitoredFile) []monitoredFile{
 	sort.Slice(files, func(i, j int) bool {
 		fileI:= files[i].file
 		fileJ:= files[j].file
-		return fileI.ModTime().Before(fileJ.ModTime())
+		return fileI.ModTime().After(fileJ.ModTime())
 
 	})
 	return files

--- a/fileUtils.go
+++ b/fileUtils.go
@@ -16,18 +16,10 @@ func getFilesForMonitoring(files []os.DirEntry, maxLength int) []os.DirEntry {
 	return filesSlice
 }
 
-func sortFilesByModTime(files []os.DirEntry) []os.DirEntry {
+func sortFilesByModTime(files []monitoredFile) []monitoredFile{
 	sort.Slice(files, func(i, j int) bool {
-		fileI, err := files[i].Info()
-		if err != nil {
-			println("Unable to read file %s , while sorting", fileI.Name())
-			os.Exit(1)
-		}
-		fileJ, err := files[j].Info()
-		if err != nil {
-			println("Unable to read file %s , while sorting", fileJ.Name())
-			os.Exit(1)
-		}
+		fileI:= files[i].file
+		fileJ:= files[j].file
 		return fileI.ModTime().Before(fileJ.ModTime())
 
 	})

--- a/fileUtils_test.go
+++ b/fileUtils_test.go
@@ -13,7 +13,7 @@ func TestDirEntriesSortedByModDateOldestFirst(t *testing.T) {
 	newFiles := make([]os.DirEntry, len(originalFiles))
 	copy(newFiles, originalFiles)
 
-	sortFilesByModTime(newFiles)
+	sortDirEntryByModTime(newFiles)
 
 	if originalFiles[1].Name() != newFiles[3].Name() {
 		t.Fail()

--- a/fileUtils_test.go
+++ b/fileUtils_test.go
@@ -7,8 +7,9 @@ import (
 )
 
 func TestDirEntriesSortedByModDateOldestFirst(t *testing.T) {
+	defer teardown()
 
-	originalFiles := []os.DirEntry{createFile("test1", false, 2), createFile("test2", false, 1), createFile("test3", false, 5), createFile("test41", false, 10)}
+	originalFiles := []os.DirEntry{createFileMock("test1", false, 2), createFileMock("test2", false, 1), createFileMock("test3", false, 5), createFileMock("test41", false, 10)}
 
 	newFiles := make([]os.DirEntry, len(originalFiles))
 	copy(newFiles, originalFiles)
@@ -21,7 +22,8 @@ func TestDirEntriesSortedByModDateOldestFirst(t *testing.T) {
 }
 
 func TestIneligbleFilesFiledInExcluded(t *testing.T) {
-	f1 := createFile("ThisIsAtestFile", false, 0)
+	defer teardown()
+	f1 := createFileMock("ThisIsAtestFile", false, 0)
 	fileNamePatterns := excludes{"test", "notMatchingPattern"}
 	excludedFiles = fileNamePatterns
 
@@ -30,7 +32,8 @@ func TestIneligbleFilesFiledInExcluded(t *testing.T) {
 	}
 }
 func TestIneligbleFilesIsDir(t *testing.T) {
-	f1 := createFile("ThisIsAtestFile", true, 0)
+	defer teardown()
+	f1 := createFileMock("ThisIsAtestFile", true, 0)
 	fileNamePatterns := excludes{"NotExcluded", "notMatchingPattern"}
 	excludedFiles = fileNamePatterns
 
@@ -40,8 +43,9 @@ func TestIneligbleFilesIsDir(t *testing.T) {
 }
 
 func TestIneligbleFilesFiledNotInExcluded(t *testing.T) {
-	f1 := createFile("ThisIsAtestFile", false, 0)
-	f2 := createFile("Sure", false, 0)
+	defer teardown()
+	f1 := createFileMock("ThisIsAtestFile", false, 0)
+	f2 := createFileMock("Sure", false, 0)
 	fileNamePatterns := excludes{"NotExcluded", "ForSure"}
 	excludedFiles = fileNamePatterns
 
@@ -53,8 +57,9 @@ func TestIneligbleFilesFiledNotInExcluded(t *testing.T) {
 	}
 }
 func TestRemovesIneligibleFiles(t *testing.T) {
-	f1 := createFile("ThisIsAtestFile", false, 0)
-	f2 := createFile("Sure", false, 0)
+	defer teardown()
+	f1 := createFileMock("ThisIsAtestFile", false, 0)
+	f2 := createFileMock("Sure", false, 0)
 	fileNamePatterns := excludes{"test", "ForSure"}
 	excludedFiles = fileNamePatterns
 
@@ -69,9 +74,12 @@ func TestRemovesIneligibleFiles(t *testing.T) {
 	}
 }
 
-func createFile(name string, isDir bool, howLongAgo int) MockDirEntry {
+func teardown() {
+	excludedFiles = excludes{}
+}
+
+func createFileMock(name string, isDir bool, howLongAgo int) MockDirEntry {
 	t := time.Now().Add(-time.Hour * time.Duration(howLongAgo))
 	mfi := MockFileInfo{FileName: name, IsDirectory: isDir, LastModTime: t}
 	return MockDirEntry{FileName: name, IsDirectory: isDir, MockInfo: mfi}
-
 }

--- a/monitoring.go
+++ b/monitoring.go
@@ -12,7 +12,7 @@ import (
 )
 
 type monitoredFile struct {
-	file os.DirEntry
+	file        os.DirEntry
 	tailProcess *os.Process
 }
 
@@ -35,7 +35,7 @@ func MonitorDir(path string, maxTails int) {
 				continue
 			}
 
-			monitoredFiles = append(monitoredFiles, tailFile(filepath.Join(path,finfo.Name()), f))
+			monitoredFiles = append(monitoredFiles, tailFile(filepath.Join(path, finfo.Name()), f))
 		}
 	}
 
@@ -86,21 +86,22 @@ func newFileCreated(path string, maxTails int, tails []monitoredFile) []monitore
 	defer f.Close()
 	if err != nil {
 		println("New file cannot be read: ", path)
-	return tails
+		return tails
 	}
 	finfo, _ := f.Stat()
 
 	if !isEligibleFile(finfo) {
-	return tails
+		println("New file is ineligible for monitoring, filename: " + finfo.Name())
+		return tails
 	}
-	
+
 	if len(tails) == maxTails {
 		tails = sortMonitoredFilesByModTime(tails)
-		mf := tails[len(tails) - 1]
+		mf := tails[len(tails)-1]
 		mf.tailProcess.Kill()
 		mf.tailProcess.Wait()
 		tails[len(tails)-1] = tailFile(path, fs.FileInfoToDirEntry(finfo))
-	}else{	
+	} else {
 		tails = append(tails, tailFile(path, fs.FileInfoToDirEntry(finfo)))
 	}
 	return tails
@@ -123,7 +124,7 @@ func tailFile(pathToFile string, file os.DirEntry) monitoredFile {
 
 func killAllTails(moniteredFiles []monitoredFile) {
 
-	for _,mf := range moniteredFiles {
+	for _, mf := range moniteredFiles {
 		mf.tailProcess.Kill()
 		mf.tailProcess.Wait()
 	}

--- a/monitoring.go
+++ b/monitoring.go
@@ -16,7 +16,7 @@ func MonitorDir(path string, maxTails int) {
 		os.Exit(1)
 	}
 
-	queue := make(chan *os.Process, maxTails)
+	monitoredFiles := make([]*os.Process, maxTails)
 	counter := 0
 	filesForMonitoring := getFilesForMonitoring(files, maxTails)
 
@@ -29,13 +29,13 @@ func MonitorDir(path string, maxTails int) {
 				continue
 			}
 
-			queue <- tailFile(path + finfo.Name())
+			monitoredFiles = append(monitoredFiles, tailFile(path + finfo.Name()))
 			counter++
 		}
 	}
 
-	defer killAllTails(queue)
-	startWatching(path, queue, counter, maxTails)
+	defer killAllTails(monitoredFiles)
+	startWatching(path, monitoredFiles, counter, maxTails)
 
 }
 
@@ -111,9 +111,9 @@ func tailFile(filePath string) *os.Process {
 	return cmd.Process
 }
 
-func killAllTails(queue chan *os.Process) {
+func killAllTails(moniteredFiles []*os.Process) {
 
-	for p := range queue {
+	for _,p := range moniteredFiles {
 		p.Kill()
 		p.Wait()
 	}

--- a/monitoring.go
+++ b/monitoring.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io/fs"
 	"log"
 	"os"
 	"os/exec"
@@ -11,7 +12,7 @@ import (
 )
 
 type monitoredFile struct {
-	file os.FileInfo
+	file os.DirEntry
 	tailProcess *os.Process
 }
 
@@ -34,7 +35,7 @@ func MonitorDir(path string, maxTails int) {
 				continue
 			}
 
-			monitoredFiles[i] = tailFile(filepath.Join(path,finfo.Name()), finfo)
+			monitoredFiles[i] = tailFile(filepath.Join(path,finfo.Name()), f)
 		}
 	}
 
@@ -98,11 +99,11 @@ func newFileCreated(path string, maxTails int, tails []monitoredFile) []monitore
 		mf.tailProcess.Kill()
 		mf.tailProcess.Wait()
 	}
-	tails[len(tails)-1] = tailFile(path,finfo)
+	tails[len(tails)-1] = tailFile(path, fs.FileInfoToDirEntry(finfo))
 	return tails
 }
 
-func tailFile(pathToFile string, file os.FileInfo) monitoredFile {
+func tailFile(pathToFile string, file os.DirEntry) monitoredFile {
 
 	app := "tail"
 	args := "-f"

--- a/monitoring.go
+++ b/monitoring.go
@@ -39,7 +39,7 @@ func MonitorDir(path string, maxTails int) {
 
 }
 
-func startWatching(path string, tails chan *os.Process, counter int, maxTails int) {
+func startWatching(path string, tails []*os.Process, counter int, maxTails int) {
 
 	w := watcher.New()
 	w.FilterOps(watcher.Create)
@@ -75,7 +75,7 @@ func startWatching(path string, tails chan *os.Process, counter int, maxTails in
 
 }
 
-func newFileCreated(path string, counter int, maxTails int, tails chan *os.Process) int {
+func newFileCreated(path string, counter int, maxTails int, tails []*os.Process) int {
 
 	f, err := os.Open(path)
 	defer f.Close()
@@ -89,13 +89,14 @@ func newFileCreated(path string, counter int, maxTails int, tails chan *os.Proce
 		return counter
 	}
 	if counter == maxTails {
-		process := <-tails
+		process := tails[counter - 1]
 		process.Kill()
 		process.Wait()
 		counter--
 	}
-	tails <- tailFile(path)
+	tails[counter - 1] = tailFile(path)
 	counter++
+	sortFilesByModTime(tails)
 	return counter
 }
 

--- a/monitoring_test.go
+++ b/monitoring_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+var testFilesDir = "testDir"
+
+func TestNewFileCreatedEmptySlice(t *testing.T) {
+
+	os.Mkdir(testFilesDir, 0755)
+	defer os.RemoveAll(testFilesDir)
+
+	maxTails := 10
+	file1 := createFile("test1")
+	mfs := make([]monitoredFile, 0, maxTails)
+	mfs = newFileCreated(file1, maxTails, mfs)
+
+	if len(mfs) != 1 {
+		println("len is not 1, it is: " + strconv.FormatInt(int64(len(mfs)), 10))
+		t.Fail()
+	}
+
+	killAllTails(mfs)
+}
+
+func TestNewFileCreatedFullSlice(t *testing.T) {
+	os.Mkdir(testFilesDir, 0755)
+	defer os.RemoveAll(testFilesDir)
+
+	maxTails := 2
+	file1 := createFile(filepath.Join(testFilesDir, "test1"))
+	file2 := createFile(filepath.Join(testFilesDir, "test2"))
+	file3 := createFile(filepath.Join(testFilesDir, "test3"))
+	mfs := make([]monitoredFile, 0, maxTails)
+	mfs = newFileCreated(file1, maxTails, mfs)
+	mfs = newFileCreated(file2, maxTails, mfs)
+	mfs = newFileCreated(file3, maxTails, mfs)
+
+	if len(mfs) != 2 {
+		println("len is not 2, it is: " + strconv.FormatInt(int64(len(mfs)), 10))
+		t.Fail()
+	}
+
+	killAllTails(mfs)
+	os.RemoveAll(testFilesDir)
+}
+
+func TestNewFileCreatedFullSliceDoesntRemoveFirstAddedFile(t *testing.T) {
+	os.Mkdir(testFilesDir, 0755)
+	defer os.RemoveAll(testFilesDir)
+
+	maxTails := 2
+	file1 := createFile(filepath.Join(testFilesDir, "test1"))
+	file2 := createFile(filepath.Join(testFilesDir, "test2"))
+	file3 := createFile(filepath.Join(testFilesDir, "test3"))
+
+	mfs := make([]monitoredFile, 0, maxTails)
+	mfs = newFileCreated(file1, maxTails, mfs)
+	mfs = newFileCreated(file2, maxTails, mfs)
+
+	f, err := os.OpenFile(file1, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0755)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	file1ExtraInput := "file1 extra input"
+	if _, err = f.WriteString(file1ExtraInput); err != nil {
+		panic(err)
+	}
+
+	mfs = newFileCreated(file3, maxTails, mfs)
+
+	if len(mfs) != 2 {
+		println("len is not 2, it is: " + strconv.FormatInt(int64(len(mfs)), 10))
+		t.Fail()
+	}
+
+	for _, mf := range mfs {
+		if mf.file.Name() == file2 {
+			println(file2 + "Should have been removed")
+			t.Fail()
+		}
+
+	}
+
+	killAllTails(mfs)
+	os.RemoveAll(testFilesDir)
+}
+func createFile(name string) string {
+	fileInput := []byte("File name is: " + name)
+	err := os.WriteFile(name, fileInput, 0644)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return name
+}


### PR DESCRIPTION
Files that a used longer than others, ex files rarely rolling but still used will now no longer be pushed out as soon. 
Ex 
log1.log gets update periodically but doesnt roll
log2.DATE.log rolls every day 

as long as log1.log gets updates more often than log2.DATE.log rolls more then the max tails amount log1.log will not cycle out